### PR TITLE
fix: Remove invalid inline media query

### DIFF
--- a/.changeset/tidy-insects-fix.md
+++ b/.changeset/tidy-insects-fix.md
@@ -1,0 +1,8 @@
+---
+"buttery-tokens": patch
+"@buttery/core": patch
+"@buttery/studio": patch
+"@buttery/studio-tokens": patch
+---
+
+Removes an invalid inline media query

--- a/packages/core/src/templates/Template.make-responsive.ts
+++ b/packages/core/src/templates/Template.make-responsive.ts
@@ -35,7 +35,7 @@ export const ${this._name}: MakeResponsive = (params) => {
   const from = params?.from ? \`\${breakpoints[params.from]}px\` : undefined;
   const to = params?.to ? \`calc(\${breakpoints[params.to]}px - 1px)\` : undefined;
   if (from && to) {
-    return \`@media (min-width: \${from}) and @media (max-width:\${to})\`;
+    return \`@media (min-width: \${from}) and (max-width:\${to})\`;
   }
   if (from && !to) {
     return \`@media (min-width: \${from})\`;


### PR DESCRIPTION
Removes an invalid inline media query for the responsive styling. This will now allow you to easily target a viewport between two breakpoints